### PR TITLE
Changed about dialog and added mapping style checker

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ subprojects {
     }
 
     group = 'cuchaz'
-    version = '1.0.7'
+    version = '1.0.8'
 
     version = version + (System.getenv("GITHUB_ACTIONS") ? "" : "+local")
 

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/config/Themes.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/config/Themes.java
@@ -1,6 +1,6 @@
 package cuchaz.enigma.gui.config;
 
-import java.awt.Font;
+import java.awt.*;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -90,7 +90,8 @@ public class Themes {
 		return ImmutableMap.of(
 				RenamableTokenType.OBFUSCATED, BoxHighlightPainter.create(UiConfig.getObfuscatedColor(), UiConfig.getObfuscatedOutlineColor()),
 				RenamableTokenType.PROPOSED, BoxHighlightPainter.create(UiConfig.getProposedColor(), UiConfig.getProposedOutlineColor()),
-				RenamableTokenType.DEOBFUSCATED, BoxHighlightPainter.create(UiConfig.getDeobfuscatedColor(), UiConfig.getDeobfuscatedOutlineColor())
+				RenamableTokenType.DEOBFUSCATED, BoxHighlightPainter.create(UiConfig.getDeobfuscatedColor(), UiConfig.getDeobfuscatedOutlineColor()),
+				RenamableTokenType.NAME_WARNING, BoxHighlightPainter.create(UiConfig.getNameWarningColor(), UiConfig.getNameWarningOutlineColor())
 		);
 	}
 

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/config/UiConfig.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/config/UiConfig.java
@@ -385,7 +385,7 @@ public final class UiConfig {
 			s.setIfAbsentRgbColor("Deobfuscated Outline", 0x50A050);
 			s.setIfAbsentDouble("Deobfuscated Outline Alpha", 1.0);
 
-			s.setIfAbsentRgbColor("NameWarning", 0xFFD700);
+			s.setIfAbsentRgbColor("NameWarning", 0xFFCB71);
 			s.setIfAbsentDouble("NameWarning Alpha", 0.8);
 			s.setIfAbsentRgbColor("NameWarning Outline", 0xFF8C00);
 			s.setIfAbsentDouble("NameWarning Outline Alpha", 1.0);
@@ -420,10 +420,10 @@ public final class UiConfig {
 			s.setIfAbsentRgbColor("Deobfuscated Outline", 0x50FA7B);
 			s.setIfAbsentDouble("Deobfuscated Outline Alpha", 0.5);
 
-			s.setIfAbsentRgbColor("NameWarning", 0xFFB86C);
-			s.setIfAbsentDouble("NameWarning Alpha", 0.3);
-			s.setIfAbsentRgbColor("NameWarning Outline", 0xFFB86C);
-			s.setIfAbsentDouble("NameWarning Outline Alpha", 0.5);
+			s.setIfAbsentRgbColor("NameWarning", 0xFF9600);
+			s.setIfAbsentDouble("NameWarning Alpha", 0.4);
+			s.setIfAbsentRgbColor("NameWarning Outline", 0xFF9600);
+			s.setIfAbsentDouble("NameWarning Outline Alpha", 0.6);
 
 			s.setIfAbsentRgbColor("Editor Background", 0x282A36);
 			s.setIfAbsentRgbColor("Highlight", 0xFF79C6);

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/config/UiConfig.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/config/UiConfig.java
@@ -1,6 +1,8 @@
 package cuchaz.enigma.gui.config;
 
 import java.awt.*;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -146,6 +148,14 @@ public final class UiConfig {
 
 	public static Color getDeobfuscatedOutlineColor() {
 		return getThemeColorRgba("Deobfuscated Outline");
+	}
+
+	public static Color getNameWarningColor() {
+		return getThemeColorRgba("NameWarning");
+	}
+
+	public static Color getNameWarningOutlineColor() {
+		return getThemeColorRgba("NameWarning Outline");
 	}
 
 	public static Color getEditorBackgroundColor() {
@@ -359,18 +369,27 @@ public final class UiConfig {
 			s.setIfAbsentRgbColor("Line Numbers Foreground", 0x333300);
 			s.setIfAbsentRgbColor("Line Numbers Background", 0xEEEEFF);
 			s.setIfAbsentRgbColor("Line Numbers Selected", 0xCCCCEE);
+
 			s.setIfAbsentRgbColor("Obfuscated", 0xFFDCDC);
 			s.setIfAbsentDouble("Obfuscated Alpha", 1.0);
 			s.setIfAbsentRgbColor("Obfuscated Outline", 0xA05050);
 			s.setIfAbsentDouble("Obfuscated Outline Alpha", 1.0);
+
 			s.setIfAbsentRgbColor("Proposed", 0x000000);
 			s.setIfAbsentDouble("Proposed Alpha", 0.15);
 			s.setIfAbsentRgbColor("Proposed Outline", 0x000000);
 			s.setIfAbsentDouble("Proposed Outline Alpha", 0.75);
+
 			s.setIfAbsentRgbColor("Deobfuscated", 0xDCFFDC);
 			s.setIfAbsentDouble("Deobfuscated Alpha", 1.0);
 			s.setIfAbsentRgbColor("Deobfuscated Outline", 0x50A050);
 			s.setIfAbsentDouble("Deobfuscated Outline Alpha", 1.0);
+
+			s.setIfAbsentRgbColor("NameWarning", 0xFFD700);
+			s.setIfAbsentDouble("NameWarning Alpha", 0.8);
+			s.setIfAbsentRgbColor("NameWarning Outline", 0xFF8C00);
+			s.setIfAbsentDouble("NameWarning Outline Alpha", 1.0);
+
 			s.setIfAbsentRgbColor("Editor Background", 0xFFFFFF);
 			s.setIfAbsentRgbColor("Highlight", 0x3333EE);
 			s.setIfAbsentRgbColor("Caret", 0x000000);
@@ -395,10 +414,17 @@ public final class UiConfig {
 			s.setIfAbsentDouble("Proposed Alpha", 0.3);
 			s.setIfAbsentRgbColor("Proposed Outline", 0x606366);
 			s.setIfAbsentDouble("Proposed Outline Alpha", 0.5);
+
 			s.setIfAbsentRgbColor("Deobfuscated", 0x50FA7B);
 			s.setIfAbsentDouble("Deobfuscated Alpha", 0.3);
 			s.setIfAbsentRgbColor("Deobfuscated Outline", 0x50FA7B);
 			s.setIfAbsentDouble("Deobfuscated Outline Alpha", 0.5);
+
+			s.setIfAbsentRgbColor("NameWarning", 0xFFB86C);
+			s.setIfAbsentDouble("NameWarning Alpha", 0.3);
+			s.setIfAbsentRgbColor("NameWarning Outline", 0xFFB86C);
+			s.setIfAbsentDouble("NameWarning Outline Alpha", 0.5);
+
 			s.setIfAbsentRgbColor("Editor Background", 0x282A36);
 			s.setIfAbsentRgbColor("Highlight", 0xFF79C6);
 			s.setIfAbsentRgbColor("Caret", 0xF8F8F2);

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/AboutDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/AboutDialog.java
@@ -20,6 +20,7 @@ import javax.swing.*;
 import cuchaz.enigma.Enigma;
 import cuchaz.enigma.gui.util.GridBagConstraintsBuilder;
 import cuchaz.enigma.gui.util.GuiUtil;
+import cuchaz.enigma.gui.util.ScaleUtil;
 import cuchaz.enigma.utils.I18n;
 
 public class AboutDialog {

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/panels/EditorPanel.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/panels/EditorPanel.java
@@ -14,7 +14,7 @@ import javax.swing.text.Highlighter.HighlightPainter;
 
 import cuchaz.enigma.analysis.index.EntryIndex;
 import cuchaz.enigma.translation.representation.AccessFlags;
-import cuchaz.enigma.translation.representation.entry.FieldEntry;
+import cuchaz.enigma.translation.representation.entry.*;
 import de.sciss.syntaxpane.DefaultSyntaxKit;
 
 import cuchaz.enigma.EnigmaProject;
@@ -42,8 +42,6 @@ import cuchaz.enigma.source.Token;
 import cuchaz.enigma.translation.mapping.EntryRemapper;
 import cuchaz.enigma.translation.mapping.EntryResolver;
 import cuchaz.enigma.translation.mapping.ResolutionStrategy;
-import cuchaz.enigma.translation.representation.entry.ClassEntry;
-import cuchaz.enigma.translation.representation.entry.Entry;
 import cuchaz.enigma.utils.I18n;
 import cuchaz.enigma.utils.Result;
 
@@ -479,17 +477,8 @@ public class EditorPanel {
 							boolean editable = t == null || this.gui.isEditable(t);
 							tokenPainter = editable ? painter : proposedPainter;
 
-							if (reference.entry instanceof FieldEntry) {
-								EntryIndex entryIndex = this.controller.project.getJarIndex().getEntryIndex();
-								AccessFlags access = entryIndex.getFieldAccess((FieldEntry)reference.entry);
-								if (access != null && access.isFinal() && access.isStatic()) {
-
-									EntryRemapper mapper = this.controller.project.getMapper();
-									String name = mapper.getDeobfMapping(reference.entry).targetName();
-									if (name != null && !name.equals(name.toUpperCase())) {
-										tokenPainter = warningPainter;
-									}
-								}
+							if (!followsStyle(reference)) {
+								tokenPainter = warningPainter;
 							}
 
 						} else {
@@ -504,6 +493,56 @@ public class EditorPanel {
 
 		this.editor.validate();
 		this.editor.repaint();
+	}
+
+	public boolean followsStyle(EntryReference<Entry<?>, Entry<?>> reference) {
+		// get the mapper and get the mapped name from the mapper
+		EntryRemapper mapper = this.controller.project.getMapper();
+		String name = mapper.getDeobfMapping(reference.entry).targetName();
+		if (name != null) {
+
+			if (reference.entry instanceof ClassEntry) {
+				// remove the path (net/minecraft/ ... /) from the class name
+				return followsClassStyle(reference, name.substring(name.lastIndexOf('/') + 1));
+			} else if (reference.entry instanceof MethodEntry) {
+				return followsMethodStyle(reference, name);
+			} else if (reference.entry instanceof FieldEntry) {
+				return followsFieldStyle(reference, name);
+			} else if (reference.entry instanceof LocalVariableEntry) {
+				return followsArgumentStyle(reference, name);
+			} else {
+				return true;
+			}
+		} else {
+			// return true if the reference isn't mapped yet
+			return true;
+		}
+	}
+
+	public boolean followsClassStyle(EntryReference<Entry<?>, Entry<?>> reference, String name) {
+		return Character.isUpperCase(name.charAt(0));
+	}
+
+	public boolean followsMethodStyle(EntryReference<Entry<?>, Entry<?>> reference, String name) {
+		if (((MethodEntry)reference.entry).isConstructor()) {
+			return followsClassStyle(reference, name);
+		} else {
+			return Character.isLowerCase(name.charAt(0));
+		}
+	}
+
+	public boolean followsArgumentStyle(EntryReference<Entry<?>, Entry<?>> reference, String name) {
+		return Character.isLowerCase(name.charAt(0));
+	}
+
+	public boolean followsFieldStyle(EntryReference<Entry<?>, Entry<?>> reference, String name) {
+		EntryIndex entryIndex = this.controller.project.getJarIndex().getEntryIndex();
+		AccessFlags access = entryIndex.getFieldAccess((FieldEntry)reference.entry);
+		if (access != null && access.isFinal() && access.isStatic()) {
+			return name == null || name.equals(name.toUpperCase());
+		} else {
+			return Character.isLowerCase(name.charAt(0));
+		}
 	}
 
 	private void addHighlightedToken(Token token, HighlightPainter tokenPainter) {

--- a/enigma/src/main/java/cuchaz/enigma/Enigma.java
+++ b/enigma/src/main/java/cuchaz/enigma/Enigma.java
@@ -37,7 +37,7 @@ import cuchaz.enigma.utils.Utils;
 public class Enigma {
     public static final String NAME = "Enigma";
 	public static final String VERSION;
-	public static final String URL = "https://quiltmc.org";
+	public static final String URL = "https://github.com/OrnitheMC/enigma";
     public static final int ASM_VERSION = Opcodes.ASM9;
 
     private final EnigmaProfile profile;

--- a/enigma/src/main/java/cuchaz/enigma/source/RenamableTokenType.java
+++ b/enigma/src/main/java/cuchaz/enigma/source/RenamableTokenType.java
@@ -3,5 +3,6 @@ package cuchaz.enigma.source;
 public enum RenamableTokenType {
 	OBFUSCATED,
 	DEOBFUSCATED,
-	PROPOSED
+	PROPOSED,
+    NAME_WARNING
 }


### PR DESCRIPTION
- changed the URL in the about dialog to one pointing to the OrintheMC github page
- Check mappings against the style guide, see issue #4 
    - Added a checker that checks `Static Final` fields to comply with our naming guide, meaning they have to be `ALL_CAPS` and separated by an `_`.
    - Checks that method names, non `Static Final` field names and argument names start with a lowercase letter
    - Checks that class names start with an upper case letter

Currently these are the colors that were chosen for this are:
Light themes:
![Screenshot 2022-01-03 160907](https://user-images.githubusercontent.com/18176360/147947335-f296073d-451e-4494-93ba-c17b93d951d4.png)

Dark themes:
![Screenshot 2022-01-03 161123](https://user-images.githubusercontent.com/18176360/147947342-f8d7ccfb-ede5-4880-8a6e-ee06d9920be2.png)

If you have any issue with these colors you can comment on this PR.

