### PR TITLE
add support for locals mapping

### DIFF
--- a/enigma/src/main/java/cuchaz/enigma/EnigmaProject.java
+++ b/enigma/src/main/java/cuchaz/enigma/EnigmaProject.java
@@ -17,19 +17,19 @@ import java.util.jar.JarOutputStream;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.google.common.base.Functions;
-import com.google.common.base.Preconditions;
-import cuchaz.enigma.api.service.ObfuscationTestService;
-import cuchaz.enigma.classprovider.ObfuscationFixClassProvider;
-import cuchaz.enigma.translation.representation.entry.ClassDefEntry;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.tree.ClassNode;
+
+import com.google.common.base.Functions;
+import com.google.common.base.Preconditions;
 
 import cuchaz.enigma.analysis.EntryReference;
 import cuchaz.enigma.analysis.index.JarIndex;
 import cuchaz.enigma.api.service.NameProposalService;
+import cuchaz.enigma.api.service.ObfuscationTestService;
 import cuchaz.enigma.bytecode.translators.TranslationClassVisitor;
 import cuchaz.enigma.classprovider.ClassProvider;
+import cuchaz.enigma.classprovider.ObfuscationFixClassProvider;
 import cuchaz.enigma.source.Decompiler;
 import cuchaz.enigma.source.DecompilerService;
 import cuchaz.enigma.source.SourceSettings;
@@ -42,7 +42,6 @@ import cuchaz.enigma.translation.mapping.tree.DeltaTrackingTree;
 import cuchaz.enigma.translation.mapping.tree.EntryTree;
 import cuchaz.enigma.translation.representation.entry.ClassEntry;
 import cuchaz.enigma.translation.representation.entry.Entry;
-import cuchaz.enigma.translation.representation.entry.LocalVariableEntry;
 import cuchaz.enigma.translation.representation.entry.MethodEntry;
 import cuchaz.enigma.utils.I18n;
 
@@ -132,10 +131,9 @@ public class EnigmaProject {
 	}
 
 	public boolean isRenamable(Entry<?> obfEntry) {
-		if (obfEntry instanceof MethodEntry obfMethodEntry) {
-			// HACKHACK: Object methods are not obfuscated identifiers
-			// HACKHACKHACK: hardcoded obfuscation format
-			String name = obfMethodEntry.getName();
+		if (obfEntry instanceof MethodEntry method) {
+			// HACKHACK: hardcoded obfuscation format
+			String name = method.getName();
 
 			if (name.startsWith("method_")) {
 				String num = name.substring(7);
@@ -147,8 +145,6 @@ public class EnigmaProject {
 				}
 			}
 
-			return false;
-		} else if (obfEntry instanceof LocalVariableEntry && !((LocalVariableEntry) obfEntry).isArgument()) {
 			return false;
 		}
 

--- a/enigma/src/main/java/cuchaz/enigma/bytecode/translators/TranslationMethodVisitor.java
+++ b/enigma/src/main/java/cuchaz/enigma/bytecode/translators/TranslationMethodVisitor.java
@@ -132,7 +132,7 @@ public class TranslationMethodVisitor extends MethodVisitor {
 	}
 
 	private String translateVariableName(int index, String name) {
-		LocalVariableEntry entry = new LocalVariableEntry(methodEntry, index, "", true,null);
+		LocalVariableEntry entry = new LocalVariableEntry(methodEntry, index, "", true, null);
 		LocalVariableEntry translatedEntry = translator.translate(entry);
 		String translatedName = translatedEntry.getName();
 

--- a/enigma/src/main/java/cuchaz/enigma/source/cfr/EnigmaDumper.java
+++ b/enigma/src/main/java/cuchaz/enigma/source/cfr/EnigmaDumper.java
@@ -12,6 +12,7 @@ import cuchaz.enigma.translation.representation.entry.Entry;
 import cuchaz.enigma.translation.representation.entry.FieldEntry;
 import cuchaz.enigma.translation.representation.entry.LocalVariableEntry;
 import cuchaz.enigma.translation.representation.entry.MethodEntry;
+
 import org.benf.cfr.reader.bytecode.analysis.loc.HasByteCodeLoc;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaRefTypeInstance;
 import org.benf.cfr.reader.bytecode.analysis.types.JavaTypeInstance;
@@ -287,6 +288,7 @@ public class EnigmaDumper extends StringStreamDumper {
     @Override
     public Dumper variableName(String name, NamedVariable variable, boolean defines) {
         // todo catch var declarations in the future
+        // will need changes to CFR
         return super.variableName(name, variable, defines);
     }
 

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/EntryRemapper.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/EntryRemapper.java
@@ -121,8 +121,17 @@ public class EntryRemapper {
 
 	@Nonnull
 	public EntryMapping getDeobfMapping(Entry<?> entry) {
-		EntryMapping entryMapping = obfToDeobf.get(entry);
-		return entryMapping == null ? EntryMapping.DEFAULT : entryMapping;
+		Collection<Entry<?>> resolvedEntries = obfResolver.resolveEntry(entry, ResolutionStrategy.RESOLVE_ROOT);
+
+ 		for (Entry<?> resolvedEntry : resolvedEntries) {
+ 			EntryMapping mapping = obfToDeobf.get(resolvedEntry);
+
+ 			if (mapping != null) {
+ 				return mapping;
+ 			}
+ 		}
+
+ 		return EntryMapping.DEFAULT;
 	}
 
 	public <T extends Translatable> TranslateResult<T> extendedDeobfuscate(T translatable) {

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/IndexEntryResolver.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/IndexEntryResolver.java
@@ -15,6 +15,7 @@ import cuchaz.enigma.translation.VoidTranslator;
 import cuchaz.enigma.translation.representation.AccessFlags;
 import cuchaz.enigma.translation.representation.entry.ClassEntry;
 import cuchaz.enigma.translation.representation.entry.Entry;
+import cuchaz.enigma.translation.representation.entry.LocalVariableEntry;
 import cuchaz.enigma.translation.representation.entry.MethodEntry;
 
 public class IndexEntryResolver implements EntryResolver {
@@ -39,7 +40,14 @@ public class IndexEntryResolver implements EntryResolver {
 			return Collections.emptySet();
 		}
 
+		// Local variables belong to a specific method implementation,
+ 		// compared to parameters, which belong to the method declaration
+ 		if (entry instanceof LocalVariableEntry l && !l.isArgument()) {
+ 			return Collections.singleton(entry);
+ 		}
+
 		Entry<ClassEntry> classChild = getClassChild(entry);
+
 		if (classChild != null && !(classChild instanceof ClassEntry)) {
 			AccessFlags access = entryIndex.getEntryAccess(classChild);
 

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/enigma/EnigmaFormat.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/enigma/EnigmaFormat.java
@@ -6,4 +6,5 @@ public class EnigmaFormat {
 	public static final String FIELD = "FIELD";
 	public static final String METHOD = "METHOD";
 	public static final String PARAMETER = "ARG";
+	public static final String LOCAL_VARIABLE = "LOCAL";
 }

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/enigma/EnigmaMappingsReader.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/enigma/EnigmaMappingsReader.java
@@ -185,7 +185,9 @@ public enum EnigmaMappingsReader implements MappingsReader {
 			case EnigmaFormat.METHOD:
 				return parseMethod(parentEntry, tokens);
 			case EnigmaFormat.PARAMETER:
-				return parseArgument(parentEntry, tokens);
+				return parseVariable(parentEntry, tokens, true);
+ 			case EnigmaFormat.LOCAL_VARIABLE:
+ 				return parseVariable(parentEntry, tokens, false);
 			case EnigmaFormat.COMMENT:
 				readJavadoc(parent, tokens);
 				return null;
@@ -308,13 +310,13 @@ public enum EnigmaMappingsReader implements MappingsReader {
 		return new MappingPair<>(obfuscatedEntry, new RawEntryMapping(mapping, modifier));
 	}
 
-	private static MappingPair<LocalVariableEntry, RawEntryMapping> parseArgument(@Nullable Entry<?> parent, String[] tokens) {
+	private static MappingPair<LocalVariableEntry, RawEntryMapping> parseVariable(@Nullable Entry<?> parent, String[] tokens, boolean parameter) {
 		if (!(parent instanceof MethodEntry)) {
-			throw new RuntimeException("Method arg must be a child of a method!");
+			throw new RuntimeException((parameter ? "Method arg" : "Local variable") + " must be a child of a method!");
 		}
 
 		MethodEntry ownerEntry = (MethodEntry) parent;
-		LocalVariableEntry obfuscatedEntry = new LocalVariableEntry(ownerEntry, Integer.parseInt(tokens[1]), "", true, null);
+		LocalVariableEntry obfuscatedEntry = new LocalVariableEntry(ownerEntry, Integer.parseInt(tokens[1]), "", parameter, null);
 		String mapping = tokens[2];
 
 		return new MappingPair<>(obfuscatedEntry, new RawEntryMapping(mapping));

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/enigma/EnigmaMappingsWriter.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/enigma/EnigmaMappingsWriter.java
@@ -219,7 +219,7 @@ public enum EnigmaMappingsWriter implements MappingsWriter {
 		} else if (entry instanceof FieldEntry fieldEntry) {
 			line = writeField(fieldEntry, mapping);
 		} else if (entry instanceof LocalVariableEntry varEntry && mapping.targetName() != null) {
-			line = writeArgument(varEntry, mapping);
+			line = writeVariable(varEntry, mapping);
 		}
 
 		if (line != null) {
@@ -290,8 +290,9 @@ public enum EnigmaMappingsWriter implements MappingsWriter {
 		return builder.toString();
 	}
 
-	protected String writeArgument(LocalVariableEntry entry, @Nonnull EntryMapping mapping) {
-		return EnigmaFormat.PARAMETER + " " + entry.getIndex() + ' ' + mapping.targetName();
+	protected String writeVariable(LocalVariableEntry entry, @Nonnull EntryMapping mapping) {
+		String type = entry.isArgument() ? EnigmaFormat.PARAMETER : EnigmaFormat.LOCAL_VARIABLE;
+		return type + " "  + entry.getIndex() + ' ' + mapping.targetName();
 	}
 
 	private void writeMapping(StringBuilder builder, EntryMapping mapping) {

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/tinyv2/TinyV2Reader.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/tinyv2/TinyV2Reader.java
@@ -253,9 +253,8 @@ public final class TinyV2Reader implements MappingsReader {
 		mapping.addJavadocLine(unescape(javadoc));
 	}
 
-
-
 	private MappingPair<LocalVariableEntry, RawEntryMapping> parseArgument(MappingPair<? extends Entry, RawEntryMapping> parent, String[] tokens, boolean escapeNames) {
+
 		MethodEntry ownerMethod = (MethodEntry) parent.getEntry();
 		int variableIndex = Integer.parseInt(tokens[1]);
 

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/Entry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/Entry.java
@@ -133,6 +133,11 @@ public interface Entry<P extends Entry<?>> extends Translatable {
 		return Objects.requireNonNull(last, () -> String.format("%s has no top level class?", this));
 	}
 
+	/**
+ 	 * Returns the ancestry of this entry, including itself.
+ 	 * The entries are listed in order from furthest to closest.
+ 	 * (i.e. this entry is last in the lis)
+ 	 */
 	default List<Entry<?>> getAncestry() {
 		P parent = getParent();
 		List<Entry<?>> entries = new ArrayList<>();


### PR DESCRIPTION
- Allow enigma to create mappings for local variables if the jar is decompiled using Procyon.
- Additions to the enigma `.mapping` format to store mappings.
- Fixed a bug that broke the `right click` -> "Reset to obfuscated" option for methods, parameters, and locals if you were not in the declaring class of the method.