### PR TITLE
Version 1.1.1: Javadoc rendering window

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Enigma
 
 A tool for deobfuscation of Java bytecode. Forked from <https://bitbucket.org/cuchaz/enigma>, copyright Jeff Martin.
+Enigma is used by Orinthe to remap, decompile and deobfuscate minecraft source code.
+This project was forked from QuiltMCs version of Enigma which was in turn forked from FabricMCs Enigma.
 
 ## License
 
@@ -17,7 +19,7 @@ Enigma includes the following open-source libraries:
 
 ## Usage
 
-Pre-compiled jars can be found on the [Quilt maven](https://maven.quiltmc.org/#browse/browse:release:cuchaz%2Fenigma-swing).
+Pre-compiled jars can be found on the [Ornithe maven](https://copetan.jfrog.io/artifactory/minecraft-maven/).
 
 ### Launching the GUI
 
@@ -26,3 +28,12 @@ Pre-compiled jars can be found on the [Quilt maven](https://maven.quiltmc.org/#b
 ### On the command line
 
 `java -cp enigma.jar cuchaz.enigma.command.Main`
+
+### Contributing
+1. Clone the project
+2. Start editing
+3. You can launch enigma using the following command to test your changes:
+```
+./gradlew :enigma-swing:run --args="-jar <jar to analyse location> -mappings <mappings location> -profile <enigma_profile.json lowation>"
+```
+Note that any of the arguments after `--args` are optional

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ subprojects {
     }
 
     group = 'net.ornithemc'
-    version = '1.1.0'
+    version = '1.1.1'
 
     version = version + (System.getenv("GITHUB_ACTIONS") ? "" : "+local")
 

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
@@ -209,41 +209,18 @@ public class JavadocDialog {
 
 	private class renderedJavadocWindowListener implements WindowListener {
 		@Override
-		public void windowOpened(WindowEvent e) {
-
-		}
-
-		@Override
 		public void windowClosing(WindowEvent e) {
 			if (renderedJavadocDialog != null) {
 				closeChildren();
 			}
 		}
 
-		@Override
-		public void windowClosed(WindowEvent e) {
-
-		}
-
-		@Override
-		public void windowIconified(WindowEvent e) {
-
-		}
-
-		@Override
-		public void windowDeiconified(WindowEvent e) {
-
-		}
-
-		@Override
-		public void windowActivated(WindowEvent e) {
-
-		}
-
-		@Override
-		public void windowDeactivated(WindowEvent e) {
-
-		}
+		@Override public void windowOpened(WindowEvent e) {}
+		@Override public void windowClosed(WindowEvent e) {}
+		@Override public void windowIconified(WindowEvent e) {}
+		@Override public void windowDeiconified(WindowEvent e) {}
+		@Override public void windowActivated(WindowEvent e) {}
+		@Override public void windowDeactivated(WindowEvent e) {}
 	}
 
 	private enum JavadocTag {

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
@@ -11,10 +11,7 @@
 
 package cuchaz.enigma.gui.dialog;
 
-import java.awt.BorderLayout;
-import java.awt.Container;
-import java.awt.Dimension;
-import java.awt.FlowLayout;
+import java.awt.*;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 
@@ -39,12 +36,14 @@ public class JavadocDialog {
 	private final JDialog ui;
 	private final GuiController controller;
 	private final Entry<?> entry;
+	private final JFrame parent;
 
 	private final ValidatableTextArea text;
 
 	private final ValidationContext vc = new ValidationContext();
 
 	private JavadocDialog(JFrame parent, GuiController controller, Entry<?> entry, String preset) {
+		this.parent = parent;
 		this.ui = new JDialog(parent, I18n.translate("javadocs.edit"));
 		this.controller = controller;
 		this.entry = entry;
@@ -58,6 +57,7 @@ public class JavadocDialog {
 		this.text.setText(preset);
 		this.text.setTabSize(2);
 		contentPane.add(new JScrollPane(this.text), BorderLayout.CENTER);
+
 		this.text.addKeyListener(new KeyAdapter() {
 			@Override
 			public void keyPressed(KeyEvent event) {
@@ -84,13 +84,21 @@ public class JavadocDialog {
 		JPanel buttonsPanel = new JPanel();
 		buttonsPanel.setLayout(new FlowLayout(FlowLayout.RIGHT));
 		buttonsPanel.add(GuiUtil.unboldLabel(new JLabel(I18n.translate("javadocs.instruction"))));
+
 		JButton cancelButton = new JButton(I18n.translate("prompt.cancel"));
 		cancelButton.addActionListener(event -> close());
 		buttonsPanel.add(cancelButton);
+
 		JButton saveButton = new JButton(I18n.translate("prompt.save"));
 		saveButton.addActionListener(event -> doSave());
 		buttonsPanel.add(saveButton);
+
+		JButton renderButton = new JButton(I18n.translate("render"));
+		renderButton.addActionListener(event -> render());
+		buttonsPanel.add(renderButton);
+
 		contentPane.add(buttonsPanel, BorderLayout.SOUTH);
+
 
 		// tags panel
 		JMenuBar tagsMenu = new JMenuBar();
@@ -150,6 +158,10 @@ public class JavadocDialog {
 		save();
 		if (!vc.canProceed()) return;
 		close();
+	}
+
+	public void render() {
+		RenderedJavadocDialog.show(this.parent, this.controller, this.text.getText());
 	}
 
 	public void close() {

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
@@ -14,6 +14,8 @@ package cuchaz.enigma.gui.dialog;
 import java.awt.*;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowListener;
 
 import javax.swing.*;
 import javax.swing.text.html.HTML;
@@ -37,6 +39,7 @@ public class JavadocDialog {
 	private final GuiController controller;
 	private final Entry<?> entry;
 	private final JFrame parent;
+	private RenderedJavadocDialog renderedJavadocDialog = null;
 
 	private final ValidatableTextArea text;
 
@@ -45,6 +48,7 @@ public class JavadocDialog {
 	private JavadocDialog(JFrame parent, GuiController controller, Entry<?> entry, String preset) {
 		this.parent = parent;
 		this.ui = new JDialog(parent, I18n.translate("javadocs.edit"));
+		this.ui.addWindowListener(new renderedJavadocWindowListener());
 		this.controller = controller;
 		this.entry = entry;
 		this.text = new ValidatableTextArea(10, 40);
@@ -130,7 +134,7 @@ public class JavadocDialog {
 		}
 
 		// add html tags
-		JComboBox<String> htmlList = new JComboBox<String>();
+		JComboBox<String> htmlList = new JComboBox<>();
 		htmlList.setPreferredSize(new Dimension());
 		for (HTML.Tag htmlTag : HTML.getAllTags()) {
 			htmlList.addItem(htmlTag.toString());
@@ -152,6 +156,7 @@ public class JavadocDialog {
 
 	// Called when the "Save" button gets clicked.
 	public void doSave() {
+		this.closeChildren();
 		vc.reset();
 		validate();
 		if (!vc.canProceed()) return;
@@ -161,12 +166,20 @@ public class JavadocDialog {
 	}
 
 	public void render() {
-		RenderedJavadocDialog.show(this.parent, this.controller, this.text.getText());
+		this.renderedJavadocDialog = new RenderedJavadocDialog(this.parent, this.controller, this.text.getText());
+		this.renderedJavadocDialog.show();
 	}
 
 	public void close() {
 		this.ui.setVisible(false);
 		this.ui.dispose();
+
+	}
+
+	public void closeChildren() {
+		if (this.renderedJavadocDialog != null && this.renderedJavadocDialog.getUi().isVisible()) {
+			this.renderedJavadocDialog.close();
+		}
 	}
 
 	public void validate() {
@@ -177,7 +190,6 @@ public class JavadocDialog {
 
 	public void save() {
 		vc.setActiveElement(text);
-
 		controller.applyChange(vc, getEntryChange());
 	}
 
@@ -193,6 +205,45 @@ public class JavadocDialog {
 		//dialog.ui.doLayout();
 		dialog.ui.setVisible(true);
 		dialog.text.grabFocus();
+	}
+
+	private class renderedJavadocWindowListener implements WindowListener {
+		@Override
+		public void windowOpened(WindowEvent e) {
+
+		}
+
+		@Override
+		public void windowClosing(WindowEvent e) {
+			if (renderedJavadocDialog != null) {
+				closeChildren();
+			}
+		}
+
+		@Override
+		public void windowClosed(WindowEvent e) {
+
+		}
+
+		@Override
+		public void windowIconified(WindowEvent e) {
+
+		}
+
+		@Override
+		public void windowDeiconified(WindowEvent e) {
+
+		}
+
+		@Override
+		public void windowActivated(WindowEvent e) {
+
+		}
+
+		@Override
+		public void windowDeactivated(WindowEvent e) {
+
+		}
 	}
 
 	private enum JavadocTag {

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
@@ -269,4 +269,8 @@ public class JavadocDialog {
 		}
 	}
 
+	public JDialog getUi() {
+		return this.ui;
+	}
+
 }

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
@@ -34,7 +34,6 @@ import cuchaz.enigma.utils.I18n;
 import cuchaz.enigma.utils.validation.ValidationContext;
 
 public class JavadocDialog {
-
 	private final JDialog ui;
 	private final GuiController controller;
 	private final Entry<?> entry;
@@ -48,7 +47,7 @@ public class JavadocDialog {
 	private JavadocDialog(JFrame parent, GuiController controller, Entry<?> entry, String preset) {
 		this.parent = parent;
 		this.ui = new JDialog(parent, I18n.translate("javadocs.edit"));
-		this.ui.addWindowListener(new renderedJavadocWindowListener());
+		this.ui.addWindowListener(new RenderedJavadocWindowListener());
 		this.controller = controller;
 		this.entry = entry;
 		this.text = new ValidatableTextArea(10, 40);
@@ -173,9 +172,11 @@ public class JavadocDialog {
 	public void close() {
 		this.ui.setVisible(false);
 		this.ui.dispose();
-
 	}
 
+	/**
+	 * Closes the all child windows. This window can only have {@link RenderedJavadocDialog} as a child.
+	 */
 	public void closeChildren() {
 		if (this.renderedJavadocDialog != null && this.renderedJavadocDialog.getUi().isVisible()) {
 			this.renderedJavadocDialog.close();
@@ -202,17 +203,25 @@ public class JavadocDialog {
 		String text = Strings.nullToEmpty(translatedReference.entry.getJavadocs());
 
 		JavadocDialog dialog = new JavadocDialog(parent, controller, entry.getNameableEntry(), text);
-		//dialog.ui.doLayout();
 		dialog.ui.setVisible(true);
 		dialog.text.grabFocus();
 	}
 
-	private class renderedJavadocWindowListener implements WindowListener {
+
+	public JDialog getUi() {
+		return this.ui;
+	}
+
+	/**
+	 * A class implementing {@link WindowListener}. This listener is used to listen to the possible child window of the {@link JavadocDialog}.
+	 * When the {@link JavadocDialog} is closed, this listener checks if there is a {@link RenderedJavadocDialog} window opened this listener will also close this child window.
+	 * To reach this behaviour only one method needs to be implemented ({@link RenderedJavadocWindowListener#windowClosing}).
+	 * the other methods therefore have empty implementations.
+	 */
+	private class RenderedJavadocWindowListener implements WindowListener {
 		@Override
 		public void windowClosing(WindowEvent e) {
-			if (renderedJavadocDialog != null) {
-				closeChildren();
-			}
+			if (renderedJavadocDialog != null) closeChildren();
 		}
 
 		@Override public void windowOpened(WindowEvent e) {}
@@ -245,9 +254,4 @@ public class JavadocDialog {
 			return this.inline;
 		}
 	}
-
-	public JDialog getUi() {
-		return this.ui;
-	}
-
 }

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/RenderedJavadocDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/RenderedJavadocDialog.java
@@ -8,6 +8,7 @@ import cuchaz.enigma.gui.TooltipEditorPane;
 import cuchaz.enigma.gui.elements.ValidatableTextArea;
 import cuchaz.enigma.gui.panels.EditorPanel;
 import cuchaz.enigma.gui.util.GuiUtil;
+import cuchaz.enigma.gui.util.JavadocAnnotationUtil;
 import cuchaz.enigma.gui.util.ScaleUtil;
 import cuchaz.enigma.translation.representation.entry.Entry;
 import cuchaz.enigma.utils.I18n;
@@ -31,7 +32,7 @@ public class RenderedJavadocDialog {
     public RenderedJavadocDialog(JFrame parent, GuiController controller, String renderText) {
         this.ui = new JDialog(parent, I18n.translate("javadocs.render"));
         this.controller = controller;
-        this.renderText =  renderText.replaceAll("\n", "<br>");
+        this.renderText = JavadocAnnotationUtil.convertRawJavadoc(renderText.replaceAll("\n", "<br>"));
         this.renderedPane.setContentType("text/html");
         this.renderedPane.setEditable(false);
 

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/RenderedJavadocDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/RenderedJavadocDialog.java
@@ -14,6 +14,8 @@ public class RenderedJavadocDialog {
     private final JEditorPane renderedPane = new JEditorPane();
     private final JScrollPane renderedScrollPane;
     private final JDialog ui;
+    // controller currently unused but will be used when the javadoc window will also need to check
+    // whether a created link is actually valid.
     private final GuiController controller;
     private final String renderText;
 
@@ -28,11 +30,12 @@ public class RenderedJavadocDialog {
         Container contentPane = ui.getContentPane();
         contentPane.setLayout(new BorderLayout());
 
-
+        // create a scrollable window and set the text to renderedText.
         this.renderedScrollPane = new JScrollPane(this.renderedPane);
         this.renderedPane.setText(this.renderText);
         contentPane.add(renderedScrollPane, BorderLayout.CENTER);
 
+        // close upon pressing escape
         this.renderedPane.addKeyListener(new KeyAdapter() {
             @Override
             public void keyPressed(KeyEvent event) {
@@ -41,8 +44,6 @@ public class RenderedJavadocDialog {
                 }
             }
         });
-
-        this.renderedPane.setText(this.renderText);
 
         // show the frame
         this.ui.setSize(ScaleUtil.getDimension(600, 400));

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/RenderedJavadocDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/RenderedJavadocDialog.java
@@ -1,21 +1,11 @@
 package cuchaz.enigma.gui.dialog;
 
-import com.google.common.base.Strings;
-import cuchaz.enigma.analysis.EntryReference;
-import cuchaz.enigma.gui.BrowserCaret;
 import cuchaz.enigma.gui.GuiController;
-import cuchaz.enigma.gui.TooltipEditorPane;
-import cuchaz.enigma.gui.elements.ValidatableTextArea;
-import cuchaz.enigma.gui.panels.EditorPanel;
-import cuchaz.enigma.gui.util.GuiUtil;
 import cuchaz.enigma.gui.util.JavadocAnnotationUtil;
 import cuchaz.enigma.gui.util.ScaleUtil;
-import cuchaz.enigma.translation.representation.entry.Entry;
 import cuchaz.enigma.utils.I18n;
-import cuchaz.enigma.utils.validation.ValidationContext;
 
 import javax.swing.*;
-import javax.swing.text.html.HTMLDocument;
 import java.awt.*;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
@@ -26,8 +16,6 @@ public class RenderedJavadocDialog {
     private final JDialog ui;
     private final GuiController controller;
     private final String renderText;
-
-    private final ValidationContext vc = new ValidationContext();
 
     public RenderedJavadocDialog(JFrame parent, GuiController controller, String renderText) {
         this.ui = new JDialog(parent, I18n.translate("javadocs.render"));
@@ -54,17 +42,6 @@ public class RenderedJavadocDialog {
             }
         });
 
-        // buttons panel
-        JPanel buttonsPanel = new JPanel();
-        buttonsPanel.setLayout(new FlowLayout(FlowLayout.RIGHT));
-        buttonsPanel.add(GuiUtil.unboldLabel(new JLabel(I18n.translate("javadocs.instruction"))));
-
-        JButton cancelButton = new JButton(I18n.translate("prompt.cancel"));
-        cancelButton.addActionListener(event -> close());
-        buttonsPanel.add(cancelButton);
-
-        contentPane.add(buttonsPanel, BorderLayout.SOUTH);
-
         this.renderedPane.setText(this.renderText);
 
         // show the frame
@@ -73,10 +50,8 @@ public class RenderedJavadocDialog {
         this.ui.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
     }
 
-    public static void show(JFrame parent, GuiController controller, String renderText) {
-        RenderedJavadocDialog dialog = new RenderedJavadocDialog(parent, controller, renderText);
-        dialog.ui.setVisible(true);
-
+    public void show() {
+        this.ui.setVisible(true);
     }
 
     public void close() {

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/RenderedJavadocDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/RenderedJavadocDialog.java
@@ -1,0 +1,85 @@
+package cuchaz.enigma.gui.dialog;
+
+import com.google.common.base.Strings;
+import cuchaz.enigma.analysis.EntryReference;
+import cuchaz.enigma.gui.BrowserCaret;
+import cuchaz.enigma.gui.GuiController;
+import cuchaz.enigma.gui.TooltipEditorPane;
+import cuchaz.enigma.gui.elements.ValidatableTextArea;
+import cuchaz.enigma.gui.panels.EditorPanel;
+import cuchaz.enigma.gui.util.GuiUtil;
+import cuchaz.enigma.gui.util.ScaleUtil;
+import cuchaz.enigma.translation.representation.entry.Entry;
+import cuchaz.enigma.utils.I18n;
+import cuchaz.enigma.utils.validation.ValidationContext;
+
+import javax.swing.*;
+import javax.swing.text.html.HTMLDocument;
+import java.awt.*;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+
+public class RenderedJavadocDialog {
+    private final JEditorPane renderedPane = new JEditorPane();
+    private final JScrollPane renderedScrollPane;
+    private final JDialog ui;
+    private final GuiController controller;
+    private final String renderText;
+
+    private final ValidationContext vc = new ValidationContext();
+
+    public RenderedJavadocDialog(JFrame parent, GuiController controller, String renderText) {
+        this.ui = new JDialog(parent, I18n.translate("javadocs.render"));
+        this.controller = controller;
+        this.renderText =  renderText.replaceAll("\n", "<br>");
+        this.renderedPane.setContentType("text/html");
+        this.renderedPane.setEditable(false);
+
+        // set up dialog
+        Container contentPane = ui.getContentPane();
+        contentPane.setLayout(new BorderLayout());
+
+
+        this.renderedScrollPane = new JScrollPane(this.renderedPane);
+        this.renderedPane.setText(this.renderText);
+        contentPane.add(renderedScrollPane, BorderLayout.CENTER);
+
+        this.renderedPane.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent event) {
+                if (event.getKeyCode() == KeyEvent.VK_ESCAPE) {
+                    close();
+                }
+            }
+        });
+
+        // buttons panel
+        JPanel buttonsPanel = new JPanel();
+        buttonsPanel.setLayout(new FlowLayout(FlowLayout.RIGHT));
+        buttonsPanel.add(GuiUtil.unboldLabel(new JLabel(I18n.translate("javadocs.instruction"))));
+
+        JButton cancelButton = new JButton(I18n.translate("prompt.cancel"));
+        cancelButton.addActionListener(event -> close());
+        buttonsPanel.add(cancelButton);
+
+        contentPane.add(buttonsPanel, BorderLayout.SOUTH);
+
+        this.renderedPane.setText(this.renderText);
+
+        // show the frame
+        this.ui.setSize(ScaleUtil.getDimension(600, 400));
+        this.ui.setLocationRelativeTo(parent);
+        this.ui.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+    }
+
+    public static void show(JFrame parent, GuiController controller, String renderText) {
+        RenderedJavadocDialog dialog = new RenderedJavadocDialog(parent, controller, renderText);
+        dialog.ui.setVisible(true);
+
+    }
+
+    public void close() {
+        this.ui.setVisible(false);
+        this.ui.dispose();
+    }
+}

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/RenderedJavadocDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/RenderedJavadocDialog.java
@@ -32,7 +32,7 @@ public class RenderedJavadocDialog {
     public RenderedJavadocDialog(JFrame parent, GuiController controller, String renderText) {
         this.ui = new JDialog(parent, I18n.translate("javadocs.render"));
         this.controller = controller;
-        this.renderText = JavadocAnnotationUtil.convertRawJavadoc(renderText.replaceAll("\n", "<br>"));
+        this.renderText = JavadocAnnotationUtil.convertRawJavadoc(renderText);
         this.renderedPane.setContentType("text/html");
         this.renderedPane.setEditable(false);
 

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/RenderedJavadocDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/RenderedJavadocDialog.java
@@ -58,4 +58,8 @@ public class RenderedJavadocDialog {
         this.ui.setVisible(false);
         this.ui.dispose();
     }
+
+    public JDialog getUi() {
+        return this.ui;
+    }
 }

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/util/JavadocAnnotationUtil.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/util/JavadocAnnotationUtil.java
@@ -13,6 +13,10 @@ public class JavadocAnnotationUtil {
     public static final Pattern OTHER_PATTERN = Pattern.compile("[\\s\\S]*");
     public static final JavadocTags[] NON_INLINES = {JavadocTags.PARAM, JavadocTags.RETURN, JavadocTags.THROWS, JavadocTags.SEE};
 
+    /**
+     * Generates a valid html link from a valid linked annotation. This tries to handle as many inputs as possible.
+     *
+     */
     public static String generateLink(String text) {
         if (text.contains("#")) {
             if (text.startsWith("#")) {
@@ -27,8 +31,8 @@ public class JavadocAnnotationUtil {
         }
     }
 
-    public static String htmlSuperscript(String text) {
-        return "<sup>" + text + "</sup>";
+    public static String htmlSuperscript(String bruh) {
+        return "<sup>" + bruh + "</sup>";
     }
 
     public static String htmlSubscript(String text) {
@@ -52,6 +56,10 @@ public class JavadocAnnotationUtil {
         return javadocList(entries, JavadocTags.PARAM);
     }
 
+    /**
+     * Runs over all entries and puts the after each other formatted like the see tag would format.
+     * @return the line in the javadoc containing all the @see entries
+     */
     public static String seeToHtml(LinkedList<String> entries) {
         StringBuilder stringBuilder = new StringBuilder(JavadocTags.SEE.getTranslation());
         int index = 0;
@@ -101,10 +109,10 @@ public class JavadocAnnotationUtil {
     }
 
     public static String convertRawJavadoc(String javadoc) {
-        javadoc = setGreen(javadoc);
         HashMap<JavadocTags, LinkedList<String>> matches = new HashMap<>();
         getMatches(javadoc, matches);
         javadoc = processMatches(javadoc, matches);
+        javadoc = setGreen(javadoc);
         return javadoc;
     }
 
@@ -146,7 +154,9 @@ public class JavadocAnnotationUtil {
 
     public static void addLineMatches(String javadoc, HashMap<JavadocTags, LinkedList<String>> matches) {
         String[] lines = javadoc.split("\n");
+        System.out.println("lines: ");
         for (String line : lines) {
+            System.out.println(line);
             for (JavadocTags tag : NON_INLINES) {
                 if (line.startsWith(tag.getText())) {
                     if (!matches.containsKey(tag)) {

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/util/JavadocAnnotationUtil.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/util/JavadocAnnotationUtil.java
@@ -44,15 +44,15 @@ public class JavadocAnnotationUtil {
     }
 
 
-    public static String returnToHtml(List<String> entries) {
+    public static String returnToHtml(LinkedList<String> entries) {
         return JavadocTags.RETURN.getTranslation() + entries.get(0).replace("@return ", "");
     }
 
-    public static String paramsToHtml(List<String> entries) {
+    public static String paramsToHtml(LinkedList<String> entries) {
         return javadocList(entries, JavadocTags.PARAM);
     }
 
-    public static String seeToHtml(List<String> entries) {
+    public static String seeToHtml(LinkedList<String> entries) {
         StringBuilder stringBuilder = new StringBuilder(JavadocTags.SEE.getTranslation());
         int index = 0;
         for (String entry : entries) {
@@ -65,15 +65,15 @@ public class JavadocAnnotationUtil {
         return stringBuilder.toString();
     }
 
-    public static String throwsToHtml(List<String> entries) {
+    public static String throwsToHtml(LinkedList<String> entries) {
         return javadocList(entries, JavadocTags.THROWS, true);
     }
 
-    public static String javadocList(List<String> entries, JavadocTags tag) {
+    public static String javadocList(LinkedList<String> entries, JavadocTags tag) {
         return javadocList(entries, tag, false);
     }
 
-    public static String javadocList(List<String> entries, JavadocTags tag, Boolean link) {
+    public static String javadocList(LinkedList<String> entries, JavadocTags tag, Boolean link) {
         StringBuilder stringBuilder = new StringBuilder(tag.getTranslation());
         int index = 0;
         for (String entry : entries) {
@@ -103,7 +103,6 @@ public class JavadocAnnotationUtil {
     public static String convertRawJavadoc(String javadoc) {
         javadoc = setGreen(javadoc);
         HashMap<JavadocTags, LinkedList<String>> lineMatches = getLineMatches(javadoc);
-        javadoc = removeTagsFromJavadoc(javadoc, lineMatches);
         HashMap<JavadocTags, LinkedList<String>> inlineMatches = getInlineMatches(new HashMap<>(), javadoc);
         for (JavadocTags tag : inlineMatches.keySet()) {
             for (String match : inlineMatches.get(tag)) {
@@ -115,15 +114,6 @@ public class JavadocAnnotationUtil {
             }
         }
         javadoc = addTagsToEnd(javadoc, lineMatches);
-        return javadoc;
-    }
-
-    public static String removeTagsFromJavadoc(String javadoc, HashMap<JavadocTags, LinkedList<String>> lineMatches) {
-        for (JavadocTags tag : lineMatches.keySet()) {
-            for (String line : lineMatches.get(tag)) {
-                javadoc = javadoc.replace(line, "");
-            }
-        }
         return javadoc;
     }
 

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/util/JavadocAnnotationUtil.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/util/JavadocAnnotationUtil.java
@@ -1,11 +1,20 @@
 package cuchaz.enigma.gui.util;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class JavadocAnnotationUtil {
     public static final String LINK_FORMAT = "<a href=\"\">%s</a>";
+    public static final String INLINE_FORMAT = "(\\{@%s ([a-zA-Z]*|\\.|#|(\\(([a-zA-Z]*|([a-zA-Z]* ))*\\)))*\\})";
+    public static final String OTHER_FORMAT = "%s";
 
     public static String generateLink(String text) {
+        System.out.println(text);
         if (text.contains("#")) {
-            return  String.format(LINK_FORMAT, text.substring(text.indexOf('#') + 1));
+            return  String.format(LINK_FORMAT, text.substring(text.lastIndexOf('#') + 1));
         } else if (text.contains(".")) {
             return String.format(LINK_FORMAT, text.substring(text.lastIndexOf('.') + 1));
         } else {
@@ -13,11 +22,19 @@ public class JavadocAnnotationUtil {
         }
     }
 
+    public static String htmlSuperscript(String text) {
+        return "<sup>" + text + "</sup>";
+    }
+
+    public static String htmlSubscript(String text) {
+        return "<sub>" + text + "</sub>";
+    }
+
     public static String linkToHtml(String text) {
         if (!text.startsWith("{@link") || !text.endsWith("}")) {
             return "";
         } else {
-            return generateLink(text.replace("{@link", "").replace("}", ""));
+            return generateLink(htmlSuperscript(text.replaceAll("(\\{@link|}| )", "")));
 
         }
     }
@@ -47,6 +64,52 @@ public class JavadocAnnotationUtil {
     }
 
     public static String convertRawJavadoc(String javadoc) {
-        return "";
+        HashSet<String> matches = getAllMatches(new HashSet<>(), javadoc);
+        for (String match : matches) {
+            javadoc = javadoc.replace(match, linkToHtml(match));
+        }
+        return javadoc;
+    }
+
+    public static HashSet<String> getAllMatches(HashSet<String> matches, String javadoc) {
+        addMatches(matches, javadoc, JavadocTags.LINK.getPattern());
+        addMatches(matches, javadoc, JavadocTags.LINKPLAIN.getPattern());
+        return matches;
+    }
+
+    public static void addMatches(HashSet<String> matches, String javadoc, String expression) {
+        Matcher m = Pattern.compile(expression).matcher(javadoc);
+        while (m.find()) {
+            matches.add(m.group());
+        }
+    }
+
+    private enum JavadocTags {
+        CODE(true, String.format(INLINE_FORMAT, "code")),
+        LINK(true, String.format(INLINE_FORMAT, "link")),
+        LINKPLAIN(true, String.format(INLINE_FORMAT, "linkplain")),
+        RETURN(false, String.format(OTHER_FORMAT, "return")),
+        SEE(false, String.format(OTHER_FORMAT, "see")),
+        THROWS(false, String.format(OTHER_FORMAT, "throws"));
+
+        private final boolean inline;
+        private final String pattern;
+
+        JavadocTags(boolean inline, String pattern) {
+            this.inline = inline;
+            this.pattern = pattern;
+        }
+
+        public String getText() {
+            return "@" + this.name().toLowerCase();
+        }
+
+        public boolean isInline() {
+            return this.inline;
+        }
+
+        public String getPattern() {
+            return this.pattern;
+        }
     }
 }

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/util/JavadocAnnotationUtil.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/util/JavadocAnnotationUtil.java
@@ -1,0 +1,52 @@
+package cuchaz.enigma.gui.util;
+
+public class JavadocAnnotationUtil {
+    public static final String LINK_FORMAT = "<a href=\"\">%s</a>";
+
+    public static String generateLink(String text) {
+        if (text.contains("#")) {
+            return  String.format(LINK_FORMAT, text.substring(text.indexOf('#') + 1));
+        } else if (text.contains(".")) {
+            return String.format(LINK_FORMAT, text.substring(text.lastIndexOf('.') + 1));
+        } else {
+            return String.format(LINK_FORMAT, text);
+        }
+    }
+
+    public static String linkToHtml(String text) {
+        if (!text.startsWith("{@link") || !text.endsWith("}")) {
+            return "";
+        } else {
+            return generateLink(text.replace("{@link", "").replace("}", ""));
+
+        }
+    }
+
+    public static String linkPlainToHtml(String text) {
+        if (!text.startsWith("{@linkplain") || !text.endsWith("}")) {
+            return "";
+        } else {
+            return generateLink(text.replace("{@linkplain", "").replace("}", ""));
+        }
+    }
+
+    public static String codeToHtml(String text) {
+        return "";
+    }
+
+    public static String returnToHtml(String text) {
+        return "";
+    }
+
+    public static String seeHtml(String text) {
+        return "";
+    }
+
+    public static String throwsToHtml(String text) {
+        return "";
+    }
+
+    public static String convertRawJavadoc(String javadoc) {
+        return "";
+    }
+}

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/util/JavadocAnnotationUtil.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/util/JavadocAnnotationUtil.java
@@ -104,6 +104,13 @@ public class JavadocAnnotationUtil {
         javadoc = setGreen(javadoc);
         HashMap<JavadocTags, LinkedList<String>> lineMatches = getLineMatches(javadoc);
         HashMap<JavadocTags, LinkedList<String>> inlineMatches = getInlineMatches(new HashMap<>(), javadoc);
+        javadoc = processInlineMatches(javadoc, inlineMatches);
+        javadoc = processLineMatches(javadoc, lineMatches);
+
+        return javadoc;
+    }
+
+    public static String processInlineMatches(String javadoc, HashMap<JavadocTags, LinkedList<String>> inlineMatches) {
         for (JavadocTags tag : inlineMatches.keySet()) {
             for (String match : inlineMatches.get(tag)) {
                 switch (tag) {
@@ -113,7 +120,16 @@ public class JavadocAnnotationUtil {
                 }
             }
         }
+        return javadoc;
+    }
+
+    public static String processLineMatches(String javadoc, HashMap<JavadocTags, LinkedList<String>> lineMatches) {
         javadoc = addTagsToEnd(javadoc, lineMatches);
+        for (JavadocTags tag : lineMatches.keySet()) {
+            for (String match : lineMatches.get(tag)) {
+                javadoc = javadoc.replace(match, "");
+            }
+        }
         return javadoc;
     }
 

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/warning/WarningChecker.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/warning/WarningChecker.java
@@ -6,15 +6,12 @@ import cuchaz.enigma.gui.Gui;
 import cuchaz.enigma.gui.GuiController;
 import cuchaz.enigma.gui.TooltipEditorPane;
 import cuchaz.enigma.source.Token;
-import cuchaz.enigma.translation.mapping.EntryMapping;
 import cuchaz.enigma.translation.mapping.EntryRemapper;
 import cuchaz.enigma.translation.representation.AccessFlags;
 import cuchaz.enigma.translation.representation.entry.*;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 public class WarningChecker {
     private final GuiController controller;
@@ -151,7 +148,7 @@ public class WarningChecker {
         String obfName = reference.entry.getName();
         if (!followsStyle(reference)) {
             this.gui.addWarningClass(WarningChecker.getClassParent(reference));
-            this.editor.setTooltipPosition(token, this.warningType.getMessage(), obfName, TooltipEditorPane.TooltipType.WARNING);
+            this.editor.setTokenTooltip(token, this.warningType.getMessage(), obfName);
             return true;
         } else if (this.editor.removeTooltip(obfName) != null){
             this.gui.removeWarningClass(WarningChecker.getClassParent(reference));

--- a/enigma/src/main/resources/lang/en_us.json
+++ b/enigma/src/main/resources/lang/en_us.json
@@ -167,6 +167,7 @@
 
 	"javadocs.edit": "Edit Javadocs",
 	"javadocs.instruction": "Edit javadocs here.",
+	"javadocs.render": "Rendered Javadoc",
 
 	"fonts.cat.default": "Default",
 	"fonts.cat.default2": "Default 2",


### PR DESCRIPTION
This update to Enigma adds a javadoc rendering window which will render javadocs so people can see how it would look. It can also be used to see how the formatting used in the javadoc (especially html formatting) would look. An example can be seen as below.
![Screenshot 2022-02-22 185014](https://user-images.githubusercontent.com/18176360/155190123-f7435e36-61e8-40f0-b353-8787ef3ca4a9.png)

